### PR TITLE
Run Problem fixes & Substance class fetch fix

### DIFF
--- a/chemspider.rb
+++ b/chemspider.rb
@@ -13,7 +13,7 @@ def query_chemspider(prev_record)
   end
 
   url = CHEMSPIDER_API + $compound
-  json_props = JSON.parse(fetch(url, "application/json"))
+  json_props = JSON.parse(fetch(url, "application/json").body)
   json_rec = json_props["Records"][0]
   if json_rec == nil
     return record

--- a/chrp.rb
+++ b/chrp.rb
@@ -51,7 +51,7 @@ def search(ssub)
     search = ssub["Search"]
   end
   if ssub["CID"] != nil
-    search = "CID#{ssub["Search"]}"
+    search = "#{ssub["CID"]}"
   end
   puts log
   query(search, ssub["Title"], abr)

--- a/dosing.rb
+++ b/dosing.rb
@@ -9,7 +9,7 @@ def query_dosing(prev_record)
 
   url = SHARVARA + $title
   json_content = fetch(url, "application/json")
-  json_props = JSON.parse(json_content)
+  json_props = JSON.parse(json_content.body)
 
   record["Dosing Info"] = []
   for dose_range in json_props

--- a/pubchem.rb
+++ b/pubchem.rb
@@ -178,7 +178,7 @@ def query_pubchem(prev_record)
     puts "failed to query: #{$compound}"
     return record
   end
-  json_props = JSON.parse(json_content)
+  json_props = JSON.parse(json_content.body)
   properties = json_props["PropertyTable"]["Properties"][0]
   for prop in REST_PROPS
     record[prop] = properties[prop]
@@ -187,14 +187,14 @@ def query_pubchem(prev_record)
   record["Title"] = $title
 
   url = PUG_VIEW + "/data/compound/#{record['PubChemId']}/JSON"
-  json_syms = JSON.parse(fetch(url, "application/json"))
+  json_syms = JSON.parse(fetch(url, "application/json").body)
   sections = json_syms["Record"]["Section"]
   sections.each do |section|
     recurse_section(record, section)
   end
 
   url = PUG_REST + "/compound/cid/#{record['PubChemId']}/description/JSON"
-  json_syms = JSON.parse(fetch(url, "application/json"))
+  json_syms = JSON.parse(fetch(url, "application/json").body)
   infos = json_syms["InformationList"]["Information"]
   #if record["Record Description"] != nil
   #  record["Record Description"] = [ record["Record Description"] ]
@@ -260,7 +260,7 @@ def query_pubchem(prev_record)
   url = PUG_REST + "/compound/cid/#{record["PubChemId"]}/synonyms/JSON"
   json_fetch = fetch(url, "application/json")
   if json_fetch != nil && json_fetch.length != 0
-    json_syms = JSON.parse(json_fetch)
+    json_syms = JSON.parse(json_fetch.body)
     synonyms = json_syms["InformationList"]["Information"][0]["Synonym"].uniq
     filtSynonyms = synonyms - [ record["Title"], record["Title"].upcase, record["Title"].downcase, "(+/-)-#{record["Title"].capitalize()}", "dl-#{record["Title"].capitalize()}", "dl-#{record["Title"]}", record["CAS"], record["IUPACName"], record["UNII"], record["DSSTox Substance ID"], record["Wikidata"] ] # record["ChemicalClasses"][0]
     filtSynonyms = filtSynonyms.reject { |str| str.start_with?("SCHEMBL") }

--- a/query.rb
+++ b/query.rb
@@ -23,6 +23,7 @@ DRUG_CLASSES = [
   "opioid",
   "stimulant",
   "depressant",
+  "benzodiazepine"
 ]
 
 PHARM = [
@@ -51,20 +52,10 @@ def query(compound, title, abr)
 
   classStrs = []
   record["DrugClasses"] = []
-  for phrm in PHARM
-    if record[phrm] != nil
-      classStrs += [ record[phrm] ]
-    end
-  end
-
-  if classStrs.length != 0
-    for desc in classStrs
-      matches = DRUG_CLASSES.select { |drug_class| desc.downcase.include?(drug_class.downcase) }
-      if matches.any?
-        record["DrugClasses"] += matches
-      end
-    end
-    record["DrugClasses"] = record["DrugClasses"].uniq
+  if record["Drug Classes"]
+    desc = record["Drug Classes"]
+    matches = DRUG_CLASSES.select { |drug_class| desc.downcase.include?(drug_class.downcase) }
+    record["DrugClasses"] = matches.uniq if matches.any?
   end
 
   generate_structure(record)

--- a/structure.rb
+++ b/structure.rb
@@ -54,7 +54,10 @@ def generate_structure(record)
     mpc += " -o \"#{cff}\""
     mpc += " -j \"#{cffj}\""
   else
-    mpc += " -o \"structure/#{$title.snakecase}.svg\""
+    def to_snake_case(str)
+      str.strip.downcase.gsub(/\s+/, '_').gsub(/[^a-z0-9_]/, '')
+    end    
+    mpc += " -o \"structure/#{to_snake_case($title)}.svg\""
     mpc += " -j \"#{vars_file}\""
   end
   ret = system(mpc)

--- a/unii.rb
+++ b/unii.rb
@@ -68,7 +68,7 @@ def query_unii(prev_record)
   end
 
   url = UNII_API + record["UNII"] + UNII_API_END
-  json_props = JSON.parse(fetch(url, "application/json"))
+  json_props = JSON.parse(fetch(url, "application/json").body)
   json_struct = json_props["structure"] # molfile, stereochemistry, opticalActivity
   if json_struct['stereochemistry'] != nil
     record["Chirality"] = json_struct['stereochemistry'].downcase


### PR DESCRIPTION
Benzodiazepines were entirely missing from the array. Additionally, because the search scanned all fetched data, including descriptions, it matched incorrect keywords. This is why alprazolam, for example, appears in the Opioid class. It simply found the keyword in the description. By restricting the keyword search to the JSON key "Drug Classes," this issue could be resolved. This mismatch might have more severe consequences for other substances, where now no keyword can be found anymore. I’ve only tested it with alprazolam. If so, a different data source should be used instead of relying on the error-prone keyword search function.

I also encountered issues running the scripts initially. After adding .body to the fetch function and manually building my own .json files based on the code’s logic, I succeeded. You might consider including those files in the repository, perhaps with examples.